### PR TITLE
Use `AsRef<Path>` for paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,9 @@ mod mmap_reader;
 
 mod engine;
 
+#[cfg(feature = "std")]
+use std::path::Path;
+
 // Re-export core types
 pub use engine::block::{VolumeShape, VoxelBlock};
 pub use engine::endian::FileEndian;
@@ -71,12 +74,12 @@ pub use mmap_reader::MmapReader;
 
 /// Open an MRC file for reading
 #[cfg(feature = "std")]
-pub fn open(path: &str) -> Result<Reader, Error> {
+pub fn open(path: impl AsRef<Path>) -> Result<Reader, Error> {
     Reader::open(path)
 }
 
 /// Create a new MRC file for writing
 #[cfg(feature = "std")]
-pub fn create(path: &str) -> WriterBuilder {
+pub fn create(path: impl AsRef<Path>) -> WriterBuilder {
     WriterBuilder::new(path)
 }

--- a/src/mmap_reader.rs
+++ b/src/mmap_reader.rs
@@ -1,5 +1,8 @@
 //! Memory-mapped MRC file reader with zero-copy API
 
+#[cfg(feature = "mmap")]
+use std::path::Path;
+
 use crate::engine::block::{VolumeShape, VoxelBlock};
 use crate::engine::codec::{EndianCodec, decode_slice};
 use crate::engine::convert::Convert;
@@ -43,7 +46,7 @@ impl MmapReader {
     ///
     /// The file is mapped read-only into the process address space.
     /// The OS will page data in/out as needed, making this efficient for large files.
-    pub fn open(path: &str) -> Result<Self, Error> {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
         use std::fs::File;
         use std::io::Read;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,5 +1,8 @@
 //! MRC file reader with iterator-centric API
 
+#[cfg(feature = "std")]
+use std::path::Path;
+
 use crate::engine::block::VolumeShape;
 use crate::engine::codec::{EndianCodec, decode_slice};
 use crate::engine::convert::Convert;
@@ -19,7 +22,7 @@ pub struct Reader {
 
 impl Reader {
     #[cfg(feature = "std")]
-    pub fn open(path: &str) -> Result<Self, Error> {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
         use std::fs::File;
         use std::io::Read;
 
@@ -58,7 +61,7 @@ impl Reader {
     }
 
     #[cfg(not(feature = "std"))]
-    pub fn open(path: &str) -> Result<Self, Error> {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, Error> {
         let _ = path;
         Err(Error::Io("std feature not enabled".into()))
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,23 +1,24 @@
 //! MRC file writer with block-based API
 
+use std::path::{Path, PathBuf};
+
 use crate::engine::block::{SliceAccess, VolumeShape, VoxelBlock};
 use crate::engine::codec::{encode_block_parallel, encode_slice};
 use crate::engine::convert::Convert;
 use crate::engine::endian::FileEndian;
 use crate::{Error, Header, Mode};
 
-use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 pub struct WriterBuilder {
-    path: String,
+    path: PathBuf,
     header: Header,
 }
 
 impl WriterBuilder {
-    pub fn new(path: &str) -> Self {
+    pub fn new(path: impl AsRef<Path>) -> Self {
         Self {
-            path: path.to_string(),
+            path: PathBuf::from(path.as_ref()),
             header: Header::new(),
         }
     }
@@ -52,7 +53,7 @@ pub struct Writer {
 
 impl Writer {
     #[cfg(feature = "std")]
-    fn create(path: &str, header: Header) -> Result<Self, Error> {
+    fn create(path: &Path, header: Header) -> Result<Self, Error> {
         use std::io::Write;
 
         if !header.validate() {
@@ -94,7 +95,7 @@ impl Writer {
     }
 
     #[cfg(not(feature = "std"))]
-    fn create(path: &str, header: Header) -> Result<Self, Error> {
+    fn create(path: &Path, header: Header) -> Result<Self, Error> {
         let _ = path;
         let _ = header;
         Err(Error::Io("std feature not enabled".into()))
@@ -292,7 +293,7 @@ pub struct MmapWriter {
 
 #[cfg(feature = "mmap")]
 impl MmapWriter {
-    pub fn create(path: &str, header: Header) -> Result<Self, Error> {
+    pub fn create(path: impl AsRef<Path>, header: Header) -> Result<Self, Error> {
         use std::fs::OpenOptions;
         use std::io::Write;
 


### PR DESCRIPTION
Thank you for building the `mrc` crate! I stumbled over the use of `&str` for paths - this is a bit inconvenient, as in general, paths can be non-UTF8, so having to call `Path::to_str()` introduces a point of failure.

With this change, users of the API can use `&str`, `&Path`, `PathBuf` etc. instead of only UTF8-valid strings.

Some [examples](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=2c1dcbf4fc830ab321e97e34679fbf10).